### PR TITLE
add api to generate oauth url with custom scope

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -33,7 +33,8 @@ var oAuthDefaultParams = {
 };
 
 var wx = {
-  generateOauthUrl: generateOauthUrl
+  generateOauthUrl: generateOauthUrl,
+  generateOauthUrlByScope: generateOauthUrlByScope
 };
 
 /**
@@ -160,22 +161,53 @@ function generateOauthUrl(myRedirectUrl, baseInfo) {
     appid: wxConfig.appId
   };
   var oauthState = wxConfig.oAuthState || 'userAuth';
-  var tempOAuthParams = {};
+  var tempOAuthParams = _.assign(tempObj, oAuthDefaultParams, {
+    redirect_uri: myRedirectUrl,
+    state: oauthState
+  });
   if(baseInfo) {
-    tempOAuthParams = _.assign(tempObj, oAuthDefaultParams, {
-      redirect_uri: myRedirectUrl,
-      scope: 'snsapi_base',
-      state: oauthState
-    });
-  } else {
-    tempOAuthParams = _.assign(tempObj, oAuthDefaultParams, {
-      redirect_uri: myRedirectUrl,
-      state: oauthState
-    });
+    tempOAuthParams.scope = 'snsapi_base';
   }
-  url += qs.stringify(tempOAuthParams);
+
+  url += qs.stringify(normalizeQuery(tempOAuthParams));
   url += redirectHash;
   return url;
+}
+
+/**
+ * gen redirect url when use wechat oauth page
+ * @param myRedirectUrl
+ * @param scope set custom scope
+ * @returns {string}
+ */
+function generateOauthUrlByScope(myRedirectUrl, scope) {
+  var url = tempUrl;
+  var tempObj = {
+    appid: wxConfig.appId
+  };
+  var oauthState = wxConfig.oAuthState || 'userAuth';
+  var tempOAuthParams = _.assign(tempObj, oAuthDefaultParams, {
+    redirect_uri: myRedirectUrl,
+    state: oauthState
+  });
+  if(scope) {
+    tempOAuthParams.scope = scope;
+  }
+
+  url += qs.stringify(normalizeQuery(tempOAuthParams));
+  url += redirectHash;
+  return url;
+}
+
+function normalizeQuery(originalQuery) {
+  var keys = Object.keys(originalQuery);
+  //sort the keys for correct order on url query
+  keys.sort();
+  var normalizedQuery = {};
+  keys.forEach(function(key) {
+    normalizedQuery[key] = originalQuery[key];
+  });
+  return normalizedQuery;
 }
 
 function getUserInfoWithToken(tokenInfo, withToken) {


### PR DESCRIPTION
fix #3 
add `generateOauthUrlByScope(myRedirectUrl, scope)` to pass custom scope instead of the default 2 scopes ("snsapi_base", "snsapi_userinfo")