### PR TITLE
decryptRefundNotifyResult

### DIFF
--- a/lib/Payment.js
+++ b/lib/Payment.js
@@ -727,10 +727,11 @@ class Payment {
       decipher.setAutoPadding(true);
       decoded = decipher.update(data, 'binary', 'utf8');
       decoded += decipher.final('utf8');
-      const ret = JSON.parse(decoded);
-      return Promise.resolve({
-        parsedXMLData: originalData,
-        decryptedData: ret,
+      return utils.parseXML(decoded).then(ret =>{
+        return Promise.resolve({
+          parsedXMLData: originalData,
+          decryptedData: ret,
+        });
       });
     });
   }

--- a/lib/Payment.js
+++ b/lib/Payment.js
@@ -723,7 +723,7 @@ class Payment {
       const md5Key = utils.genMD5(this.getAPISignKey());
       data = utils.createBufferFromBase64(data.req_info);
       let decoded;
-      const decipher = crypto.createDecipher('aes-256-ecb', md5Key);
+      const decipher = crypto.createDecipheriv('aes-256-ecb', md5Key, Buffer.alloc(0));
       decipher.setAutoPadding(true);
       decoded = decipher.update(data, 'binary', 'utf8');
       decoded += decipher.final('utf8');


### PR DESCRIPTION
Fixed decryptRefundNotifyResult
1. crypto.createDecipher deprecated, use crypto.createDecipheriv() instead.
2.decode data.req_info之后是一个XML，需要先parseXML